### PR TITLE
Swift-ier Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 Test.playground
 Test.playground/*
+*.xcworkspace/
+xcuserdata/

--- a/CheatyXML/CheatyXML.swift
+++ b/CheatyXML/CheatyXML.swift
@@ -9,198 +9,181 @@
 import Foundation
 
 public class XMLParser: NSObject, NSXMLParserDelegate {
-    
+
     public class XMLElement: NSObject, SequenceType, GeneratorType {
-        
-        public let tagName: String!
-        public var attributes: [NSObject: AnyObject]! {
-            get {
-                return self._attributes
-            }
-        }
-        
+
+        public let tagName: String?
+        public let attributes: [NSObject: AnyObject]
+
         public var count: Int {
             get {
-                if self._parentElement == nil {
+                guard let element = self._parentElement, tagName = self.tagName else {
                     return 1
                 }
-                
-                let array: [XMLElement] = self._parentElement.arrayOfElementsNamed(self.tagName)
-                return array.count
+
+                return element.arrayOfElementsNamed(tagName).count
             }
         }
-        
+
         public var numberOfChildElements: Int {
             get {
                 return self._subElements?.count ?? 0
             }
         }
-        
-        private var _subElements: [XMLElement]!
+
+        private var _subElements: [XMLElement]?
         private var _content: String?
-        private var _parentElement: XMLElement!
-        private var _attributes: [NSObject: AnyObject]!
+        private var _parentElement: XMLElement?
         private var _generatorIndex: Int = 0
-        
-        //override public var debugDescription: String { get { return self.description() } }
-        
+
+        public override var debugDescription: String { get { return self.description } }
+
         public var stringValue: String! {
             get { return self._content! }
         }
-        
+
         public var string: String? {
             get { return self._content }
         }
-        
-        init(tagName: String!) {
+
+        init(tagName: String?, attributes: [NSObject: AnyObject]) {
             self.tagName = tagName
+            self.attributes = attributes
         }
-        
-        // Problem with Swift 1.2
-        /*public func description() -> String {
-            return "XMLElement <\(self.tagName)>, attributes(\(self.attributes?.count ?? 0)): \(self.attributes), children: \(self._subElements?.count ?? 0)"
-        }*/
-        
+
+        public override var description: String {
+            return "XMLElement <\(self.tagName)>, attributes(\(self.attributes.count ?? 0)): \(self.attributes), children: \(self._subElements?.count ?? 0)"
+        }
+
         public func generate() -> XMLElement {
             self._generatorIndex = 0
             return self
         }
-        
+
         public func next() -> XMLElement? {
-            if self._generatorIndex < 0 || self._generatorIndex >= self._subElements.count {
+            if self._generatorIndex < 0 || self._generatorIndex >= self._subElements?.count {
                 return nil
             }
-            
-            return self._subElements[self._generatorIndex++]
+
+            return self._subElements?[self._generatorIndex++]
         }
-        
+
         public func elementsNamed(name: String) -> [XMLElement] {
             return self.arrayOfElementsNamed(name)
         }
-        
-        private final func arrayOfElementsNamed(tagName: String) -> [XMLElement]! {
-            return self._subElements.filter({(element: XMLElement) -> Bool in
+
+        private final func arrayOfElementsNamed(tagName: String) -> [XMLElement] {
+            return self._subElements?.filter({(element: XMLElement) -> Bool in
                 return element.tagName == tagName
-            })
+            }) ?? Array()
         }
-        
+
         private final func addSubElement(subElement: XMLElement) {
             if self._subElements == nil {
                 self._subElements = []
             }
-            
-            self._subElements.append(subElement)
+
+            self._subElements?.append(subElement)
         }
-        
-        public subscript(tagName: String) -> XMLElement! {
+
+        public subscript(tagName: String) -> XMLElement {
             get {
                 return self[tagName, 0]
             }
         }
-        
-        public subscript(index: Int) -> XMLElement! {
+
+        public subscript(index: Int) -> XMLElement {
             get {
-                return self._parentElement[self.tagName, index]
+				if let parentElement = self._parentElement, tagName = self.tagName {
+					return parentElement[tagName, index]
+				} else {
+					return XMLNullElement()
+				}
             }
         }
-        
-        public subscript(tagName: String, index: Int) -> XMLElement! {
+
+        public subscript(tagName: String, index: Int) -> XMLElement {
             get {
                 if index < 0 {
                     return XMLNullElement()
                 }
-                
-                let array = self._subElements.filter({(element: XMLElement) -> Bool in
+
+                let array = self._subElements?.filter({(element: XMLElement) -> Bool in
                     return element.tagName == tagName
-                })
-                
+                }) ?? Array()
+
                 if index >= array.count {
                     return XMLNullElement()
                 }
-                
+
                 return array[index]
             }
         }
     }
-    
+
     public class XMLNullElement: XMLElement {
-        
-        init() { super.init(tagName: nil) }
-        
-        // Problem with Swift 1.2
-        /*public override func description() -> String {
+
+        init() { super.init(tagName: nil, attributes: Dictionary()) }
+
+        public override var description: String {
             return "XMLNullElement"
-        }*/
-        
-        public override subscript(tagName: String) -> XMLElement! {
+        }
+
+        public override subscript(tagName: String) -> XMLElement {
             get { return XMLNullElement() }
         }
-        
-        public override subscript(index: Int) -> XMLElement! {
+
+        public override subscript(index: Int) -> XMLElement {
             get { return XMLNullElement() }
         }
-        
-        public override subscript(tagName: String, index: Int) -> XMLElement! {
+
+        public override subscript(tagName: String, index: Int) -> XMLElement {
             get { return XMLNullElement() }
         }
     }
-    
-    public var rootElement: XMLElement! {
-        get {
-            return self._rootElement
-        }
-    }
-    
-    private let _xmlParser: NSXMLParser!
+
+    public private(set) var rootElement: XMLElement?
+    private let _xmlParser: NSXMLParser
     private var _pointerTree: [COpaquePointer]!
-    private var _rootElement: XMLElement!
-    
-    public init?(contentsOfURL: NSURL) {
-        self._xmlParser = NSXMLParser(contentsOfURL: contentsOfURL)
-        
-        super.init()
-        if !self.initXMLParser() {
+	private let _regex: NSRegularExpression = try! NSRegularExpression(pattern: "[^\\n\\s]+", options: [])
+
+    public convenience init?(contentsOfURL: NSURL) {
+        guard let xmlParser = NSXMLParser(contentsOfURL: contentsOfURL) else {
             return nil
         }
+
+        self.init(xmlParser: xmlParser)
     }
-    
-    public init?(data: NSData!) {
-        self._xmlParser = data != nil ? NSXMLParser(data: data) : nil
-        
-        super.init()
-        if self._xmlParser == nil {
+
+    public convenience init?(data: NSData?) {
+        guard let data = data else {
             return nil
         }
-        
-        if !self.initXMLParser() {
-            return nil
-        }
+
+        self.init(xmlParser: NSXMLParser(data: data))
     }
-    
+
     public convenience init?(string: String) {
         self.init(data: NSString(string: string).dataUsingEncoding(NSUTF8StringEncoding))
     }
-    
-    private func initXMLParser() -> Bool {
-        if self._xmlParser == nil {
-            return false
-        }
-        
+
+    private init?(xmlParser: NSXMLParser) {
+        self._xmlParser = xmlParser
+        super.init()
+
         self._xmlParser.delegate = self
-        return self._xmlParser.parse()
+
+        if self._xmlParser.parse() == false {
+            return nil
+        }
     }
-    
+
     public final func parser(parser: NSXMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String : String]) {
-        
-        let newElement: XMLElement = XMLElement(tagName: elementName)
-        if self._rootElement == nil {
-            self._rootElement = newElement
+        let newElement: XMLElement = XMLElement(tagName: elementName, attributes: attributeDict)
+        if self.rootElement == nil {
+            self.rootElement = newElement
         }
-        
-        if !attributeDict.isEmpty {
-            newElement._attributes = attributeDict
-        }
-        
+
         if self._pointerTree == nil {
             self._pointerTree = []
         } else {
@@ -208,35 +191,35 @@ public class XMLParser: NSObject, NSXMLParserDelegate {
             newElement._parentElement = nps.memory
             nps.memory.addSubElement(newElement)
         }
-    
+
         let ps = UnsafeMutablePointer<XMLElement>.alloc(1)
         ps.initialize(newElement)
         let cps = COpaquePointer(ps)
         self._pointerTree.append(cps)
     }
-    
+
     public final func parser(parser: NSXMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
         self._pointerTree.removeLast()
     }
-    
+
     public final func parser(parser: NSXMLParser, foundCharacters string: String) {
         let nps = UnsafeMutablePointer<XMLElement>(self._pointerTree.last!)
-        var tmpString: String! = nps.memory._content ?? ""
-        tmpString! += string
-        
-        let regex: NSRegularExpression = try! NSRegularExpression(pattern: "[^\\n\\s]+", options: [])
-        if regex.matchesInString(tmpString, options: [], range: NSMakeRange(0, tmpString.characters.count)).count <= 0 {
-            tmpString = nil
+        var tmpString = nps.memory._content ?? ""
+        tmpString += string
+
+        if self._regex.matchesInString(tmpString, options: [], range: NSMakeRange(0, tmpString.characters.count)).count > 0 {
+            nps.memory._content = tmpString
+        } else {
+            nps.memory._content = nil
         }
-        
-        nps.memory._content = tmpString
     }
-    
-    public subscript(tagName: String) -> XMLElement! {
-        return self._rootElement[tagName]
+
+    public subscript(tagName: String) -> XMLElement {
+        return self.rootElement?[tagName] ?? XMLNullElement()
     }
-    
-    public subscript(tagName: String, index: Int) -> XMLElement! {
-        return self._rootElement[tagName, index]
+
+    public subscript(tagName: String, index: Int) -> XMLElement {
+		return self.rootElement?[tagName, index] ?? XMLNullElement()
     }
+
 }

--- a/CheatyXML/CheatyXML.swift
+++ b/CheatyXML/CheatyXML.swift
@@ -13,7 +13,7 @@ public class XMLParser: NSObject, NSXMLParserDelegate {
     public class XMLElement: NSObject, SequenceType, GeneratorType {
 
         public let tagName: String?
-        public let attributes: [NSObject: AnyObject]
+        public let attributes: [String: String]
 
         public var count: Int {
             get {
@@ -46,7 +46,7 @@ public class XMLParser: NSObject, NSXMLParserDelegate {
             get { return self._content }
         }
 
-        init(tagName: String?, attributes: [NSObject: AnyObject]) {
+        init(tagName: String?, attributes: [String: String]) {
             self.tagName = tagName
             self.attributes = attributes
         }


### PR DESCRIPTION
- Now taking advantage of Swift 2 features like guard
- Removed most internal implicit optionals as they were prone to crashes
- Removed all external implicit optionals since XMLNullElement was already taking care of that
- Reworked init’s to drop the need for initXMLParser
- Removed redundant private/public properties where possible
- Restored description overrides
- Minor performance improvement by making the NSRegularExpression object a class constant instead of creating everytime parser:foundCharacters: is called
